### PR TITLE
Fixed error on the checkout flow when "flatrate_flatrate" shipping me…

### DIFF
--- a/tests/_support/Page/Acceptance/Checkout.php
+++ b/tests/_support/Page/Acceptance/Checkout.php
@@ -30,8 +30,8 @@ class Checkout
     public static $paymentButtonsContainer = '#payment-buttons-container';
     public static $checkoutReviewContainer = '#checkout-review-submit';
 
-    public static $shippingMethodInput = '#s_method_flatrate_flatrate';
-    public static $shippingMethod = 'flatrate_flatrate';
+    public static $shippingMethodInput = 'form input[name=shipping_method]';
+    public static $shippingMethod = '';
     public static $paymentMethod = '#p_method_checkmo';
 
     /**


### PR DESCRIPTION
Fixed error on the checkout flow when "flatrate_flatrate" shipping method is unavailable.

It will select the first available shipping method instead of "flatrate_flatrate"
